### PR TITLE
Fix plugin API endpoint to report status of all GPIOs

### DIFF
--- a/octoprint_gpiocontrol/__init__.py
+++ b/octoprint_gpiocontrol/__init__.py
@@ -124,7 +124,11 @@ class GpioControlPlugin(
         return dict(turnGpioOn=["id"], turnGpioOff=["id"], getGpioState=["id"])
 
     def on_api_get(self, request):
-        return self.on_api_command("getGpioState", [])
+        configuration = self._settings.get(["gpio_configurations"])
+        result = {}
+        for idx, gpio in enumerate(configuration):
+            result[idx] = str(self.on_api_command("getGpioState", {"id": idx}).get_json())
+        return flask.jsonify(result)
 
     def on_api_command(self, command, data):
         configuration = self._settings.get(["gpio_configurations"])[int(data["id"])]


### PR DESCRIPTION
Hey. First of all, thanks for the nice plugin!
While migrating away from PSUControl and LEDControl for this plugin I realized that I struggle to integrate it into my home automation system. For this I need a generic API endpoint which reports the state of the GPIOs. Optimally it would be possible to request each GPIOs state by a unique endpoint like `/api/plugin/gpiocontrol/{id}` but I realized that doesn't seem possible with OctoPrints plugin architecture.
Therefore I went with the next best thing and fixed the `on_api_get` endpoint (which was broken since it supplied an empty list as data argument to `on_api_command`). It now returns a list with all configured GPIOs with their current status:

```
sqozz@workstation ~ » curl -s -H "Content-Type: application/json" -H "X-Api-Key: [redacted]" http://octoprint/api/plugin/gpiocontrol
{"0":"on"}
```

It uses the data from `on_api_command` to produce a consistent result in case you decide to change the output of it.
Let me know if there are some improvements I should implement :)