### PR TITLE
Keeping GPIO state in memory in case of wrong GPIO.input(xx) reading.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_gpiocontrol"
 plugin_name = "OctoPrint-GpioControl"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.0.8"
+plugin_version = "1.0.9"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
Some code refactoring and fix displaying proper GPIO state based on information in memory instead asking GPIO.input() > for same cases it doesn't works if power consumption from GPIO is to high - like using GPIO for switching on LED. On disconnected GPIOs it works fine.